### PR TITLE
Add boa to featured section

### DIFF
--- a/prod/featured.section
+++ b/prod/featured.section
@@ -1,3 +1,4 @@
+boa
 nordpass
 joplin-desktop
 onionshare


### PR DESCRIPTION
There's a new release of the Blade of Agony game due on the 30th April. It would be great if the snapped version could be featured in the store at the same time.